### PR TITLE
removed explicit parameters in main.js

### DIFF
--- a/dev/main.js
+++ b/dev/main.js
@@ -1,7 +1,3 @@
 
 import {renderXatkitWidget} from "../index";
-import avatar from '@assets/xatkit-avatar.png';
-import launcherImage from '@assets/xatkit-avatar-negative.png';
-//renderXatkitWidget();
-renderXatkitWidget(undefined, 'bot','xatkit-chat','My title', 'My subtitle', true,'My placeholder',avatar,launcherImage );
-
+renderXatkitWidget();


### PR DESCRIPTION
Removed explicit parameters from renderXatkitWidget, they are already defined in the default parameters.

@hamzaed can you check this is correct? It works on my local installation but maybe I am missing something.